### PR TITLE
Fix the link of ActiveValue

### DIFF
--- a/SeaORM/docs/03-generate-entity/03-expanded-entity-structure.md
+++ b/SeaORM/docs/03-generate-entity/03-expanded-entity-structure.md
@@ -135,7 +135,7 @@ pub struct Model {
 
 ## Active Model
 
-An `ActiveModel` has all the attributes of its corresponding `Model` but all attributes are wrapped in an [`ActiveValue`](https://docs.rs/sea-orm/0.5/sea_orm/entity/struct.ActiveValue.html).
+An `ActiveModel` has all the attributes of its corresponding `Model` but all attributes are wrapped in an [`ActiveValue`](https://docs.rs/sea-orm/0.5/sea_orm/entity/enum.ActiveValue.html).
 
 ```rust
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
The link of `ActiveValue` gives `The requested resource does not exist` .