### PR TITLE
Add reference to SQLite URI Filenames in Connect Options

### DIFF
--- a/SeaORM/versioned_docs/version-0.7.x/02-install-and-config/03-connection.md
+++ b/SeaORM/versioned_docs/version-0.7.x/02-install-and-config/03-connection.md
@@ -31,3 +31,5 @@ opt.max_connections(100)
 
 let db = Database::connect(opt).await?;
 ```
+
+To configure the underlying SQLite database use SQLite's [URI Filenames](https://www.sqlite.org/c3ref/open.html). As an example, to open a database for read and write, creating the database if it is missing, we would specify `sqlite://data.db?mode=rwc`.


### PR DESCRIPTION
In many ORMs and connectors the SQLite database is configured through functions such as `.create_if_missing(true)`. SeaORM does not provide this to prevent leaking abstractions that make no sense for Postgres or MySQL, leaving the user to configure the SQLite filename.

All of the existing examples in SeaORM use `sqlite::memory:` and a user making an intuitive guess of `sqlite:data.db` or `sqlite://data.db` whilst trying for a persistent SQLite database will be met with errors regarding not finding / opening the given file.

I propose adding a brief mention to the SeaORM documentation directing the users to SQLite's URI filenames and providing the specific example of `sqlite://data.db?mode=rwc` which would likely cover the majority of use cases. Guidance on achieving clearer writing or finding a better home for this content in the documentation is welcomed.
