### PR TITLE
Clarify that DeriveRelation only covers RelationTrait

### DIFF
--- a/SeaORM/docs/07-relation/01-one-to-one.md
+++ b/SeaORM/docs/07-relation/01-one-to-one.md
@@ -31,7 +31,7 @@ impl Related<super::fruit::Entity> for Entity {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the `RelationTrait` implementaion above:
+where the following eliminates the need for the `RelationTrait` implementation above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -75,7 +75,7 @@ impl Related<super::cake::Entity> for Entity {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the `RelationTrait` implementaion above:
+where the following eliminates the need for the `RelationTrait` implementation above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/SeaORM/docs/07-relation/01-one-to-one.md
+++ b/SeaORM/docs/07-relation/01-one-to-one.md
@@ -31,7 +31,7 @@ impl Related<super::fruit::Entity> for Entity {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the above:
+where the following is equivalent to the `RelationTrait` implementaion above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -75,7 +75,7 @@ impl Related<super::cake::Entity> for Entity {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the above:
+where the following is equivalent to the `RelationTrait` implementaion above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/SeaORM/docs/07-relation/02-one-to-many.md
+++ b/SeaORM/docs/07-relation/02-one-to-many.md
@@ -28,7 +28,7 @@ impl Related<super::fruit::Entity> for Entity {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the above:
+where the following is equivalent to the `RelationTrait` implementaion above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -67,7 +67,7 @@ impl Related<super::cake::Entity> for Entity {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the above:
+where the following is equivalent to the `RelationTrait` implementaion above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/SeaORM/docs/07-relation/02-one-to-many.md
+++ b/SeaORM/docs/07-relation/02-one-to-many.md
@@ -28,7 +28,7 @@ impl Related<super::fruit::Entity> for Entity {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the `RelationTrait` implementaion above:
+where the following eliminates the need for the `RelationTrait` implementation above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -67,7 +67,7 @@ impl Related<super::cake::Entity> for Entity {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the `RelationTrait` implementaion above:
+where the following eliminates the need for the `RelationTrait` implementation above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/SeaORM/docs/07-relation/03-many-to-many.md
+++ b/SeaORM/docs/07-relation/03-many-to-many.md
@@ -67,7 +67,7 @@ impl RelationTrait for Relation {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the `RelationTrait` implementaion above:
+where the following eliminates the need for the `RelationTrait` implementation above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/SeaORM/docs/07-relation/03-many-to-many.md
+++ b/SeaORM/docs/07-relation/03-many-to-many.md
@@ -67,7 +67,7 @@ impl RelationTrait for Relation {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the above:
+where the following is equivalent to the `RelationTrait` implementaion above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/SeaORM/versioned_docs/version-0.5.x/06-relation/01-one-to-one.md
+++ b/SeaORM/versioned_docs/version-0.5.x/06-relation/01-one-to-one.md
@@ -31,7 +31,7 @@ impl Related<super::fruit::Entity> for Entity {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the above:
+where the following eliminates the need for the `RelationTrait` implementation above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -75,7 +75,7 @@ impl Related<super::cake::Entity> for Entity {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the above:
+where the following eliminates the need for the `RelationTrait` implementation above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/SeaORM/versioned_docs/version-0.5.x/06-relation/02-one-to-many.md
+++ b/SeaORM/versioned_docs/version-0.5.x/06-relation/02-one-to-many.md
@@ -28,7 +28,7 @@ impl Related<super::fruit::Entity> for Entity {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the above:
+where the following eliminates the need for the `RelationTrait` implementation above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -67,7 +67,7 @@ impl Related<super::cake::Entity> for Entity {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the above:
+where the following eliminates the need for the `RelationTrait` implementation above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/SeaORM/versioned_docs/version-0.5.x/06-relation/03-many-to-many.md
+++ b/SeaORM/versioned_docs/version-0.5.x/06-relation/03-many-to-many.md
@@ -67,7 +67,7 @@ impl RelationTrait for Relation {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the above:
+where the following eliminates the need for the `RelationTrait` implementation above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/SeaORM/versioned_docs/version-0.6.x/07-relation/01-one-to-one.md
+++ b/SeaORM/versioned_docs/version-0.6.x/07-relation/01-one-to-one.md
@@ -31,7 +31,7 @@ impl Related<super::fruit::Entity> for Entity {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the above:
+where the following eliminates the need for the `RelationTrait` implementation above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -75,7 +75,7 @@ impl Related<super::cake::Entity> for Entity {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the above:
+where the following eliminates the need for the `RelationTrait` implementation above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/SeaORM/versioned_docs/version-0.6.x/07-relation/02-one-to-many.md
+++ b/SeaORM/versioned_docs/version-0.6.x/07-relation/02-one-to-many.md
@@ -28,7 +28,7 @@ impl Related<super::fruit::Entity> for Entity {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the above:
+where the following eliminates the need for the `RelationTrait` implementation above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -67,7 +67,7 @@ impl Related<super::cake::Entity> for Entity {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the above:
+where the following eliminates the need for the `RelationTrait` implementation above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/SeaORM/versioned_docs/version-0.6.x/07-relation/03-many-to-many.md
+++ b/SeaORM/versioned_docs/version-0.6.x/07-relation/03-many-to-many.md
@@ -67,7 +67,7 @@ impl RelationTrait for Relation {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the above:
+where the following eliminates the need for the `RelationTrait` implementation above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/SeaORM/versioned_docs/version-0.7.x/07-relation/01-one-to-one.md
+++ b/SeaORM/versioned_docs/version-0.7.x/07-relation/01-one-to-one.md
@@ -31,7 +31,7 @@ impl Related<super::fruit::Entity> for Entity {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the above:
+where the following eliminates the need for the `RelationTrait` implementation above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -75,7 +75,7 @@ impl Related<super::cake::Entity> for Entity {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the above:
+where the following eliminates the need for the `RelationTrait` implementation above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/SeaORM/versioned_docs/version-0.7.x/07-relation/02-one-to-many.md
+++ b/SeaORM/versioned_docs/version-0.7.x/07-relation/02-one-to-many.md
@@ -28,7 +28,7 @@ impl Related<super::fruit::Entity> for Entity {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the above:
+where the following eliminates the need for the `RelationTrait` implementation above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -67,7 +67,7 @@ impl Related<super::cake::Entity> for Entity {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the above:
+where the following eliminates the need for the `RelationTrait` implementation above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/SeaORM/versioned_docs/version-0.7.x/07-relation/03-many-to-many.md
+++ b/SeaORM/versioned_docs/version-0.7.x/07-relation/03-many-to-many.md
@@ -67,7 +67,7 @@ impl RelationTrait for Relation {
 ```
 
 Alternatively, the definition can be shortened by the `DeriveRelation` macro,
-where the following is equivalent to the above:
+where the following eliminates the need for the `RelationTrait` implementation above:
 
 ```rust
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]


### PR DESCRIPTION
## PR Info

- Closes seaql/sea-orm#669

## Fixes

- Adds some clarifying language to indicate that the `DeriveRelation` macro covers only the `RelationTrait`.
