### PR TITLE
Update "sea-orm-cli generate" command example

### DIFF
--- a/SeaORM/docs/03-generate-entity/01-sea-orm-cli.md
+++ b/SeaORM/docs/03-generate-entity/01-sea-orm-cli.md
@@ -51,8 +51,8 @@ Command line options:
 - `--with-serde`: automatically derive serde Serialize / Deserialize traits for the entity (`none`, `serialize`, `deserialize`, `both`) (default: `none`)
 
 ```shell
-# Generate entity files of database `bakery` to `src/entity`
+# Generate entity files of database `bakery` to `entity/src`
 $ sea-orm-cli generate entity \
     -u sql://sea:sea@localhost/bakery \
-    -o src/entity
+    -o entity/src
 ```


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info
Seeing following examples, it looks like --output-dir option should be "entity/src" instead of "src/entity".
https://github.com/SeaQL/sea-orm/tree/master/examples

If my understanding is not correct, please just close this.

## Changes
Change value of --output-dir option in "sea-orm-cli generate" example
