### PR TITLE
Add Nix installation instructions

### DIFF
--- a/SeaORM/docs/04-generate-entity/01-sea-orm-cli.md
+++ b/SeaORM/docs/04-generate-entity/01-sea-orm-cli.md
@@ -6,6 +6,12 @@ First, install `sea-orm-cli` with `cargo`.
 $ cargo install sea-orm-cli
 ```
 
+Alternatively, you can install the CLI using [Nix](https://nixos.org):
+
+```shell
+$ nix-env -iA sea-orm-cli
+```
+
 ## Configure Environment
 
 Set `DATABASE_URL` in your environment, or create a `.env` file in your project root. Specify your database connection.


### PR DESCRIPTION
## Adds

- Installation instructions for installing the Sea ORM CLI using Nix/Nixpkgs (I'm in the process of adding a [`sea-orm-cli`](https://github.com/NixOS/nixpkgs/pull/183971/files) package). This PR, if accepted, should be merged only when that lands.
