### PR TITLE
SeaORM docs: SQLite doesn't support `u64`

### DIFF
--- a/SeaORM/docs/04-generate-entity/02-entity-structure.md
+++ b/SeaORM/docs/04-generate-entity/02-entity-structure.md
@@ -71,7 +71,7 @@ For the mappings of Rust primitive data types.
 | `i32` | Integer | integer | int | integer |
 | `u32` | Unsigned | integer | int unsigned | N/A |
 | `i64` | BigInteger | integer | bigint | bigint |
-| `u64` | BigUnsigned | integer | bigint unsigned | N/A |
+| `u64` | BigUnsigned | N/A | bigint unsigned | N/A |
 | `f32` | Float | real | float | real |
 | `f64` | Double | real | double | double precision |
 | `bool` | Boolean | integer | bool | bool |

--- a/SeaORM/versioned_docs/version-0.10.x/04-generate-entity/02-entity-structure.md
+++ b/SeaORM/versioned_docs/version-0.10.x/04-generate-entity/02-entity-structure.md
@@ -71,7 +71,7 @@ For the mappings of Rust primitive data types.
 | `i32` | Integer | integer | int | integer |
 | `u32` | Unsigned | integer | int unsigned | N/A |
 | `i64` | BigInteger | integer | bigint | bigint |
-| `u64` | BigUnsigned | integer | bigint unsigned | N/A |
+| `u64` | BigUnsigned | N/A | bigint unsigned | N/A |
 | `f32` | Float | real | float | real |
 | `f64` | Double | real | double | double precision |
 | `bool` | Boolean | integer | bool | bool |


### PR DESCRIPTION
## PR Info

- Related to https://github.com/SeaQL/sea-orm/issues/1400

## Changes

- [x] SQLite doesn't support `u64`
