### PR TITLE
Update 02-writing-migration.md

### DIFF
--- a/SeaORM/versioned_docs/version-0.11.x/03-migration/02-writing-migration.md
+++ b/SeaORM/versioned_docs/version-0.11.x/03-migration/02-writing-migration.md
@@ -280,6 +280,7 @@ You can write migration files in raw SQL, but then you lost the multi-backend co
 ```rust title="migration/src/m20220101_000001_create_table.rs"
 use sea_orm::Statement;
 use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::ConnectionTrait;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;


### PR DESCRIPTION
Adds a missing import for the raw SQL migration example to work out of the box.


## PR Info

<!-- mention the related issue -->
- Closes no issue, should I create one? 

## Changes

- [x] updates the documentation so one can copy paste the code and it works 