### PR TITLE
Update the list of database driver support to include SQLx MariaDB

### DIFF
--- a/SeaORM/versioned_docs/version-0.12.x/02-install-and-config/01-database-and-async-runtime.md
+++ b/SeaORM/versioned_docs/version-0.12.x/02-install-and-config/01-database-and-async-runtime.md
@@ -16,7 +16,7 @@ You must choose a `DATABASE_DRIVER` and an `ASYNC_RUNTIME`. `macros` is needed i
 
 You can choose one or more from:
 
-+ `sqlx-mysql` - SQLx MySQL
++ `sqlx-mysql` - SQLx MySQL and MariaDB
 + `sqlx-postgres` - SQLx PostgreSQL
 + `sqlx-sqlite` - SQLx SQLite
 


### PR DESCRIPTION
As https://github.com/launchbadge/sqlx suggested, SQLx has support for MariaDB. Update the documentation to reflect that.