### PR TITLE
Add sea-orm-cli command options regarding generated enum

### DIFF
--- a/SeaORM/docs/04-generate-entity/01-sea-orm-cli.md
+++ b/SeaORM/docs/04-generate-entity/01-sea-orm-cli.md
@@ -63,6 +63,8 @@ Command line options:
 - `--max-connections`: maximum number of database connections to be initialized in the connection pool (default: `1`)
 - `--model-extra-derives`: append extra derive macros to the generated model struct
 - `--model-extra-attributes`: append extra attributes to generated model struct
+- `--enum-extra-derives`: append extra derive macros to generated enums
+- `--enum-extra-attributes`: append extra attributes to generated enums
 - `--seaography`: generate addition structs in entities for seaography integration
 
 ```shell

--- a/SeaORM/versioned_docs/version-0.12.x/04-generate-entity/01-sea-orm-cli.md
+++ b/SeaORM/versioned_docs/version-0.12.x/04-generate-entity/01-sea-orm-cli.md
@@ -57,6 +57,8 @@ Command line options:
 - `--max-connections`: maximum number of database connections to be initialized in the connection pool (default: `1`)
 - `--model-extra-derives`: append extra derive macros to the generated model struct
 - `--model-extra-attributes`: append extra attributes to generated model struct
+- `--enum-extra-derives`: append extra derive macros to generated enums
+- `--enum_extra_attributes`: append extra attributes to generated enums
 - `--seaography`: generate addition structs in entities for seaography integration
 
 ```shell

--- a/SeaORM/versioned_docs/version-0.12.x/04-generate-entity/01-sea-orm-cli.md
+++ b/SeaORM/versioned_docs/version-0.12.x/04-generate-entity/01-sea-orm-cli.md
@@ -58,7 +58,7 @@ Command line options:
 - `--model-extra-derives`: append extra derive macros to the generated model struct
 - `--model-extra-attributes`: append extra attributes to generated model struct
 - `--enum-extra-derives`: append extra derive macros to generated enums
-- `--enum_extra_attributes`: append extra attributes to generated enums
+- `--enum-extra-attributes`: append extra attributes to generated enums
 - `--seaography`: generate addition structs in entities for seaography integration
 
 ```shell


### PR DESCRIPTION

According to the `Fields` listed in variant `Entity` of enum [`GenerateSubcommands`](https://docs.rs/sea-orm-cli/latest/sea_orm_cli/cli/enum.GenerateSubcommands.html), command line options to add extra derives and attributes to generated enums have also been introduced into sea orm cli.

