### PR TITLE
Fix broken GitHub release link

### DIFF
--- a/Blog/blog/2024-08-04-sea-orm-1.0.md
+++ b/Blog/blog/2024-08-04-sea-orm-1.0.md
@@ -11,7 +11,7 @@ tags: [news]
 
 <img alt="SeaORM 1.0 Banner" src="/blog/img/SeaORM%201.0%20Banner.png"/>
 
-🎉 We are pleased to release [SeaORM 1.0](https://github.com/SeaQL/sea-orm/releases/tag/1.0) today! This is an special occasion for us, so this blog post will be a little more than a release notes.
+🎉 We are pleased to release [SeaORM 1.0](https://github.com/SeaQL/sea-orm/releases/tag/1.0.0) today! This is an special occasion for us, so this blog post will be a little more than a release notes.
 
 ## Our Journey
 


### PR DESCRIPTION
## PR Info

This PR fixes a broken link in the blog post about the 1.0 release (congratulations btw!):

![Screenshot from 2024-08-06 20-31-35](https://github.com/user-attachments/assets/9d12eb6e-87b0-4d8b-8081-a19e727ae4a9)

After making this change:

![Screenshot from 2024-08-06 20-32-42](https://github.com/user-attachments/assets/fed729ed-71d1-42cf-80e6-0f93934b4943)

Keep up the great work!