### PR TITLE
Fix Create Data Type section in 02-writing-migration.md

### DIFF
--- a/SeaORM/docs/03-migration/02-writing-migration.md
+++ b/SeaORM/docs/03-migration/02-writing-migration.md
@@ -167,6 +167,7 @@ Here are some common DDL snippets you may find useful.
 - Create Data Type (PostgreSQL only)
     ```rust
     use sea_orm::{EnumIter, Iterable};
+    use sea_orm_migration::prelude::extension::postgres::Type;
 
     #[derive(DeriveIden)]
     struct CategoryEnum;
@@ -183,6 +184,7 @@ Here are some common DDL snippets you may find useful.
             Type::create()
                 .as_enum(CategoryEnum)
                 .values(CategoryVariants::iter())
+                .to_owned()
         )
         .await?;
     ```

--- a/SeaORM/versioned_docs/version-1.0.x/03-migration/02-writing-migration.md
+++ b/SeaORM/versioned_docs/version-1.0.x/03-migration/02-writing-migration.md
@@ -167,6 +167,7 @@ Here are some common DDL snippets you may find useful.
 - Create Data Type (PostgreSQL only)
     ```rust
     use sea_orm::{EnumIter, Iterable};
+    use sea_orm_migration::prelude::extension::postgres::Type;
 
     #[derive(DeriveIden)]
     struct CategoryEnum;
@@ -183,6 +184,7 @@ Here are some common DDL snippets you may find useful.
             Type::create()
                 .as_enum(CategoryEnum)
                 .values(CategoryVariants::iter())
+                .to_owned()
         )
         .await?;
     ```


### PR DESCRIPTION
This is to fix 2 compile errors.
- Add Type import to fix the following error:
    - error[E0433]: failed to resolve: use of undeclared type `Type`
- Add `to_owned()` method to fix the following error:
    - expected `TypeCreateStatement`, found `&mut TypeCreateStatement`

## Changes

- [x] Fixes 2 compile errors in sample code in document.
