### PR TITLE
fix pattern matching for DbErr::ConnectionAcquire

### DIFF
--- a/SeaORM/docs/02-install-and-config/02-connection.md
+++ b/SeaORM/docs/02-install-and-config/02-connection.md
@@ -94,7 +94,7 @@ Checks if a connection to the database is still valid.
 async fn check(db: DatabaseConnection) {
     assert!(db.ping().await.is_ok());
     db.clone().close().await;
-    assert!(matches!(db.ping().await, Err(DbErr::ConnectionAcquire)));
+    assert!(matches!(db.ping().await, Err(DbErr::ConnectionAcquire(_))));
 }
 ```
 


### PR DESCRIPTION
The example in "Check if connection is valid" fails to compile because `DbErr::ConnectionAcquire` is a tuple variant.
Fixed by adding `(_)` to the `matches!` macro.