### PR TITLE
Examples page: fix 404 URLs

### DIFF
--- a/SeaORM-X/docs/01-introduction/02-tutorial.md
+++ b/SeaORM-X/docs/01-introduction/02-tutorial.md
@@ -4,16 +4,16 @@ If you prefer a step-by-step tutorial on how to use SeaORM, check out the offici
 
 The [SeaORM Cookbook](https://www.sea-ql.org/sea-orm-cookbook/) covers frequently asked questions and recommended practices.
 
-For a minimal working example in a single file, try the [Quickstart](https://github.com/SeaQL/sea-orm-x/blob/master/examples/quickstart/src/main.rs).
+For a minimal working example in a single file, try the [Quickstart](https://github.com/SeaQL/sea-orm/blob/master/examples/quickstart/src/main.rs).
 
 ## Integration Examples
 
-+ [Actix Example](https://github.com/SeaQL/sea-orm-x/tree/master/examples/actix_example)
-+ [Axum Example](https://github.com/SeaQL/sea-orm-x/tree/master/examples/axum_example)
-+ [GraphQL Example](https://github.com/SeaQL/sea-orm-x/tree/master/examples/graphql_example)
-+ [jsonrpsee Example](https://github.com/SeaQL/sea-orm-x/tree/master/examples/jsonrpsee_example)
-+ [Loco Example](https://github.com/SeaQL/sea-orm-x/tree/master/examples/loco_example) / [Loco REST Starter](https://github.com/SeaQL/sea-orm-x/tree/master/examples/loco_starter)
-+ [Poem Example](https://github.com/SeaQL/sea-orm-x/tree/master/examples/poem_example)
-+ [Salvo Example](https://github.com/SeaQL/sea-orm-x/tree/master/examples/salvo_example)
-+ [Tonic Example](https://github.com/SeaQL/sea-orm-x/tree/master/examples/tonic_example)
-+ [Seaography Example](https://github.com/SeaQL/sea-orm-x/tree/master/examples/seaography_example)
++ [Actix Example](https://github.com/SeaQL/sea-orm/tree/master/examples/actix_example)
++ [Axum Example](https://github.com/SeaQL/sea-orm/tree/master/examples/axum_example)
++ [GraphQL Example](https://github.com/SeaQL/sea-orm/tree/master/examples/graphql_example)
++ [jsonrpsee Example](https://github.com/SeaQL/sea-orm/tree/master/examples/jsonrpsee_example)
++ [Loco Example](https://github.com/SeaQL/sea-orm/tree/master/examples/loco_example) / [Loco REST Starter](https://github.com/SeaQL/sea-orm-x/tree/master/examples/loco_starter)
++ [Poem Example](https://github.com/SeaQL/sea-orm/tree/master/examples/poem_example)
++ [Salvo Example](https://github.com/SeaQL/sea-orm/tree/master/examples/salvo_example)
++ [Tonic Example](https://github.com/SeaQL/sea-orm/tree/master/examples/tonic_example)
++ [Seaography Example](https://github.com/SeaQL/sea-orm/tree/master/examples/seaography_example)


### PR DESCRIPTION
from `sea-orm-x` to `sea-orm`

