### PR TITLE
Update MySQL section to include MariaDB

### DIFF
--- a/SeaORM/docs/02-install-and-config/02-connection.md
+++ b/SeaORM/docs/02-install-and-config/02-connection.md
@@ -33,7 +33,7 @@ Multiple queries will execute in parallel as you `await` on them.
 
 Here are some tips for database specific options:
 
-### MySQL
+### MySQL and MariaDB
 
 ```
 mysql://username:password@host/database


### PR DESCRIPTION
The connection page only listed MySQL, while Database & Async Runtime (https://www.sea-ql.org/SeaORM/docs/install-and-config/database-and-async-runtime/) already documents MariaDB via sqlx-mysql. MariaDB uses the same mysql:// URL format; this aligns the connection page.