### PR TITLE
docs: document the --tables flag for generate entity

### DIFF
--- a/SeaORM/docs/04-generate-entity/01-sea-orm-cli.md
+++ b/SeaORM/docs/04-generate-entity/01-sea-orm-cli.md
@@ -53,6 +53,7 @@ Command line options:
 - `-v` / `--verbose`: print debug messages
 - `-l` / `--lib`: generate index file as `lib.rs` instead of `mod.rs`
 - `--include-hidden-tables`: generate entity files from hidden tables (tables with names starting with an underscore are hidden and ignored by default)
+- `-t` / `--tables`: generate entity file for specified tables only (comma separated)
 - `--ignore-tables`: skip generating entity file for specified tables (default: `seaql_migrations`)
 - `--compact-format`: generate entity file of [compact format](04-generate-entity/02-entity-format.md) (default: true)
 - `--expanded-format`: generate entity file of [expanded format](13-internal-design/05-expanded-entity-format.md)


### PR DESCRIPTION
  ## PR Info

  - Closes: N/A

  ## New Features

  N/A

  ## Bug Fixes

  N/A

  ## Breaking Changes

  N/A

  ## Changes

  - [x] Document the `--tables` (`-t`) flag for `sea-orm-cli generate entity`

  The `--tables` flag has been part of the CLI for several releases but is missing
  from the documentation. This adds a single bullet point in
  `SeaORM/docs/04-generate-entity/01-sea-orm-cli.md`, matching the style of the
  existing `--ignore-tables` entry.

  Verified against `sea-orm-cli 2.0.0-rc.38 --help`.

  Source reference: https://github.com/SeaQL/sea-orm/blob/2.0.0-rc.38/sea-orm-cli/src/cli.rs
